### PR TITLE
Refine donation display with pagination and flexible formats

### DIFF
--- a/src/app/(site)/contribute/page.tsx
+++ b/src/app/(site)/contribute/page.tsx
@@ -1,9 +1,8 @@
-import Link from 'next/link'
 import ProductCard from '@/components/product-card'
+import DonationInstitutionsList from '@/components/donation-institutions-list'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Button } from '@/components/ui/button'
 import { sb } from '@/lib/supabase-server'
+import { DonationInfo } from '@/lib/donation'
 
 export const metadata = {
   title: '기여 — 후원/구매/참여',
@@ -14,10 +13,7 @@ type Institution = {
   id: number
   name: string
   slug: string
-  donation?: {
-    account?: string | null
-    page_url?: string | null
-  } | null
+  donation?: DonationInfo | null
 }
 
 type Product = {
@@ -43,8 +39,19 @@ const fallbackInstitutions: Institution[] = [
     name: '서울 베네딕도회',
     slug: 'seoul-benedictine',
     donation: {
-      account: '국민은행 123456-78-901234',
-      page_url: '#'
+      methods: [
+        {
+          type: 'bank_account',
+          bank: '국민은행',
+          holder: '서울 베네딕도회',
+          number: '123456-78-901234'
+        },
+        {
+          type: 'link',
+          label: '온라인 후원 페이지',
+          url: '#'
+        }
+      ]
     }
   },
   {
@@ -52,8 +59,15 @@ const fallbackInstitutions: Institution[] = [
     name: '춘천 카르멜 수녀원',
     slug: 'chuncheon-carmelite',
     donation: {
-      account: '농협 987-65-432109',
-      page_url: '#'
+      methods: [
+        {
+          type: 'bank_account',
+          bank: '농협',
+          holder: '춘천 카르멜 수녀원',
+          number: '987-65-432109',
+          description: '정기 후원 계좌'
+        }
+      ]
     }
   }
 ]
@@ -121,32 +135,7 @@ export default async function ContributePage() {
       </TabsList>
 
       <TabsContent value="donate">
-        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-          {institutions.map((institution) => (
-            <Card key={institution.id} className="h-full">
-              <CardHeader className="pb-3">
-                <CardTitle className="text-base">{institution.name}</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-2 text-sm">
-                {institution.donation?.account ? (
-                  <div>
-                    계좌: <span className="font-semibold">{institution.donation.account}</span>
-                  </div>
-                ) : (
-                  <p className="text-muted-foreground">후원 계좌 정보가 준비 중입니다.</p>
-                )}
-                {institution.donation?.page_url ? (
-                  <a className="underline" href={institution.donation.page_url} target="_blank" rel="noreferrer noopener">
-                    후원 페이지
-                  </a>
-                ) : null}
-                <Button asChild size="sm" variant="secondary">
-                  <Link href={`/institutions/${institution.slug}`}>기관 페이지</Link>
-                </Button>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
+        <DonationInstitutionsList institutions={institutions} />
       </TabsContent>
 
       <TabsContent value="buy">

--- a/src/app/(site)/institutions/[slug]/page.tsx
+++ b/src/app/(site)/institutions/[slug]/page.tsx
@@ -3,14 +3,11 @@ import Link from 'next/link'
 import InstitutionHero from '@/components/institution-hero'
 import NaverMap from '@/components/naver-map'
 import ProductCard from '@/components/product-card'
+import DonationMethodList from '@/components/donation-method-list'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { sb } from '@/lib/supabase-server'
-
-type Donation = {
-  account?: string | null
-  page_url?: string | null
-}
+import { DonationInfo, normalizeDonationMethods } from '@/lib/donation'
 
 type Institution = {
   id: number
@@ -24,7 +21,7 @@ type Institution = {
   phone?: string | null
   email?: string | null
   website_url?: string | null
-  donation?: Donation | null
+  donation?: DonationInfo | null
 }
 
 type Product = {
@@ -57,8 +54,19 @@ const fallbackInstitution: Institution = {
   email: 'info@seoul-benedictine.kr',
   website_url: 'https://example.com',
   donation: {
-    account: '국민은행 123456-78-901234',
-    page_url: 'https://example.com/donate'
+    methods: [
+      {
+        type: 'bank_account',
+        bank: '국민은행',
+        holder: '서울 베네딕도회',
+        number: '123456-78-901234'
+      },
+      {
+        type: 'link',
+        label: '공식 후원 페이지',
+        url: 'https://example.com/donate'
+      }
+    ]
   }
 }
 
@@ -139,6 +147,7 @@ export default async function InstitutionPage({ params }: { params: { slug: stri
   const { institution, products, events } = await fetchInstitution(params.slug)
 
   const center = institution.lat && institution.lng ? { lat: institution.lat, lng: institution.lng } : null
+  const donationMethods = normalizeDonationMethods(institution.donation)
 
   return (
     <div className="space-y-6">
@@ -163,18 +172,14 @@ export default async function InstitutionPage({ params }: { params: { slug: stri
           <CardHeader>
             <CardTitle>후원</CardTitle>
           </CardHeader>
-          <CardContent className="space-y-2 text-sm">
-            {institution.donation?.account ? (
-              <div>
-                계좌: <span className="font-medium">{institution.donation.account}</span>
-              </div>
+          <CardContent className="space-y-3 text-sm">
+            {donationMethods.length ? (
+              <DonationMethodList methods={donationMethods} />
             ) : (
-              <p className="text-muted-foreground">후원 계좌 정보가 준비 중입니다.</p>
+              <p className="text-muted-foreground">후원 정보가 준비 중입니다.</p>
             )}
-            {institution.donation?.page_url ? (
-              <a className="underline" href={institution.donation.page_url} target="_blank" rel="noreferrer noopener">
-                후원 페이지 바로가기
-              </a>
+            {institution.donation?.note ? (
+              <p className="text-muted-foreground">{institution.donation.note}</p>
             ) : null}
           </CardContent>
         </Card>

--- a/src/components/donation-institutions-list.tsx
+++ b/src/components/donation-institutions-list.tsx
@@ -1,0 +1,100 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useMemo, useState } from 'react'
+import DonationMethodList from '@/components/donation-method-list'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { DonationInfo, normalizeDonationMethods } from '@/lib/donation'
+
+const ITEMS_PER_PAGE = 6
+
+type Institution = {
+  id: number | string
+  name: string
+  slug: string
+  donation?: DonationInfo | null
+}
+
+type Props = {
+  institutions: Institution[]
+}
+
+export default function DonationInstitutionsList({ institutions }: Props) {
+  const institutionsWithDonation = useMemo(
+    () =>
+      institutions
+        .map((institution) => ({
+          ...institution,
+          methods: normalizeDonationMethods(institution.donation)
+        }))
+        .filter((institution) => institution.methods.length > 0),
+    [institutions]
+  )
+
+  const [page, setPage] = useState(1)
+  const totalPages = Math.max(1, Math.ceil(institutionsWithDonation.length / ITEMS_PER_PAGE))
+
+  useEffect(() => {
+    setPage((prev) => Math.min(prev, totalPages))
+  }, [totalPages])
+
+  const startIndex = (page - 1) * ITEMS_PER_PAGE
+  const paginatedInstitutions = institutionsWithDonation.slice(startIndex, startIndex + ITEMS_PER_PAGE)
+
+  if (!institutionsWithDonation.length) {
+    return <p className="text-sm text-muted-foreground">현재 표시할 후원 기관이 없습니다.</p>
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {paginatedInstitutions.map((institution) => (
+          <Card key={institution.id} className="h-full">
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base">{institution.name}</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm">
+              <DonationMethodList methods={institution.methods} />
+              <Button asChild size="sm" variant="secondary">
+                <Link href={`/institutions/${institution.slug}`}>기관 페이지</Link>
+              </Button>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {totalPages > 1 ? (
+        <div className="flex flex-col gap-3 text-sm sm:flex-row sm:items-center sm:justify-between">
+          <span className="text-muted-foreground">
+            총 {institutionsWithDonation.length}곳 중 {startIndex + 1}–
+            {Math.min(startIndex + ITEMS_PER_PAGE, institutionsWithDonation.length)} 표시 중
+          </span>
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => setPage((prev) => Math.max(1, prev - 1))}
+              disabled={page === 1}
+            >
+              이전
+            </Button>
+            <span className="tabular-nums">
+              {page} / {totalPages}
+            </span>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => setPage((prev) => Math.min(totalPages, prev + 1))}
+              disabled={page === totalPages}
+            >
+              다음
+            </Button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/donation-method-list.tsx
+++ b/src/components/donation-method-list.tsx
@@ -1,0 +1,73 @@
+import { DonationMethod } from '@/lib/donation'
+import { cn } from '@/lib/utils'
+
+type DonationMethodListProps = {
+  methods: DonationMethod[]
+  className?: string
+}
+
+export default function DonationMethodList({ methods, className }: DonationMethodListProps) {
+  if (!methods.length) return null
+
+  return (
+    <div className={cn('space-y-2 text-sm', className)}>
+      {methods.map((method, index) => {
+        const key = `${method.type}-${index}`
+
+        switch (method.type) {
+          case 'bank_account': {
+            return (
+              <div key={key} className="space-y-1">
+                {method.bank ? (
+                  <div>
+                    은행: <span className="font-medium">{method.bank}</span>
+                  </div>
+                ) : null}
+                {method.holder ? (
+                  <div>
+                    예금주: <span className="font-medium">{method.holder}</span>
+                  </div>
+                ) : null}
+                {method.number ? (
+                  <div>
+                    계좌번호: <span className="font-semibold tracking-wide">{method.number}</span>
+                  </div>
+                ) : null}
+                {method.description ? <p className="text-muted-foreground">{method.description}</p> : null}
+              </div>
+            )
+          }
+          case 'link': {
+            return (
+              <a
+                key={key}
+                className="inline-flex items-center gap-1 font-medium underline"
+                href={method.url}
+                target="_blank"
+                rel="noreferrer noopener"
+              >
+                {method.label ?? '후원 링크'}
+                <span aria-hidden>↗</span>
+              </a>
+            )
+          }
+          case 'custom': {
+            return (
+              <div key={key}>
+                {method.label ? (
+                  <>
+                    {method.label}: <span className="font-medium">{method.value}</span>
+                  </>
+                ) : (
+                  <span className="font-medium">{method.value}</span>
+                )}
+              </div>
+            )
+          }
+          default:
+            return null
+        }
+      })}
+    </div>
+  )
+}

--- a/src/lib/donation.ts
+++ b/src/lib/donation.ts
@@ -1,0 +1,109 @@
+export type BankAccountDonationMethod = {
+  type: 'bank_account'
+  bank?: string | null
+  holder?: string | null
+  number?: string | null
+  description?: string | null
+}
+
+export type LinkDonationMethod = {
+  type: 'link'
+  label?: string | null
+  url: string
+}
+
+export type CustomDonationMethod = {
+  type: 'custom'
+  label?: string | null
+  value: string
+}
+
+export type DonationMethod = BankAccountDonationMethod | LinkDonationMethod | CustomDonationMethod
+
+export type DonationInfo = {
+  methods?: DonationMethod[] | null
+  account?: string | null
+  page_url?: string | null
+  note?: string | null
+}
+
+function isBankAccountMethod(method: DonationMethod): method is BankAccountDonationMethod {
+  return method.type === 'bank_account'
+}
+
+function isLinkMethod(method: DonationMethod): method is LinkDonationMethod {
+  return method.type === 'link'
+}
+
+function hasContent(method: DonationMethod): boolean {
+  if (isBankAccountMethod(method)) {
+    return Boolean(method.bank || method.holder || method.number || method.description)
+  }
+
+  if (isLinkMethod(method)) {
+    return Boolean(method.url)
+  }
+
+  return Boolean(method.value)
+}
+
+export function normalizeDonationMethods(donation?: DonationInfo | null): DonationMethod[] {
+  if (!donation) return []
+
+  const normalized: DonationMethod[] = []
+
+  if (Array.isArray(donation.methods)) {
+    for (const method of donation.methods) {
+      if (!method || typeof method !== 'object') continue
+      if (method.type === 'bank_account') {
+        const bankMethod: BankAccountDonationMethod = {
+          type: 'bank_account',
+          bank: method.bank ?? null,
+          holder: method.holder ?? null,
+          number: method.number ?? null,
+          description: method.description ?? null
+        }
+        if (hasContent(bankMethod)) normalized.push(bankMethod)
+      } else if (method.type === 'link' && method.url) {
+        normalized.push({
+          type: 'link',
+          url: method.url,
+          label: method.label ?? null
+        })
+      } else if (method.type === 'custom' && method.value) {
+        normalized.push({
+          type: 'custom',
+          value: method.value,
+          label: method.label ?? null
+        })
+      }
+    }
+  }
+
+  if (donation.account) {
+    normalized.push({
+      type: 'bank_account',
+      number: donation.account
+    })
+  }
+
+  if (donation.page_url) {
+    const alreadyHasLink = normalized.some(
+      (method) => method.type === 'link' && method.url === donation.page_url
+    )
+
+    if (!alreadyHasLink) {
+      normalized.push({
+        type: 'link',
+        url: donation.page_url,
+        label: donation.note ? undefined : '후원 페이지'
+      })
+    }
+  }
+
+  return normalized.filter(hasContent)
+}
+
+export function hasDonationDetails(donation?: DonationInfo | null): boolean {
+  return normalizeDonationMethods(donation).length > 0
+}


### PR DESCRIPTION
## Summary
- hide institutions without donation info and paginate the donation tab for a clearer experience
- add shared donation method utilities/components to support bank accounts, links, and custom entries on list and detail pages

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d42db939e0832a9e8bfdef6b77d677