### PR TITLE
Improve donation method normalization

### DIFF
--- a/src/lib/donation.ts
+++ b/src/lib/donation.ts
@@ -27,6 +27,36 @@ export type DonationInfo = {
   note?: string | null
 }
 
+type DonationRecord = DonationInfo & Record<string, unknown>
+
+function toOptionalString(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    return trimmed.length ? trimmed : undefined
+  }
+
+  return undefined
+}
+
+function parseDonation(value: unknown): DonationRecord | null {
+  if (!value) return null
+
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value)
+      if (parsed && typeof parsed === 'object') {
+        return parsed as DonationRecord
+      }
+    } catch {
+      return null
+    }
+  }
+
+  if (typeof value !== 'object') return null
+
+  return value as DonationRecord
+}
+
 function isBankAccountMethod(method: DonationMethod): method is BankAccountDonationMethod {
   return method.type === 'bank_account'
 }
@@ -48,56 +78,117 @@ function hasContent(method: DonationMethod): boolean {
 }
 
 export function normalizeDonationMethods(donation?: DonationInfo | null): DonationMethod[] {
-  if (!donation) return []
+  const donationObject = parseDonation(donation)
+  if (!donationObject) return []
 
   const normalized: DonationMethod[] = []
+  const note = toOptionalString(donationObject.note)
 
-  if (Array.isArray(donation.methods)) {
-    for (const method of donation.methods) {
-      if (!method || typeof method !== 'object') continue
+  if (Array.isArray(donationObject.methods)) {
+    for (const method of donationObject.methods) {
+      if (!method) continue
+
+      if (typeof method === 'string') {
+        const url = toOptionalString(method)
+        if (url) {
+          normalized.push({ type: 'link', url })
+        }
+        continue
+      }
+
+      if (typeof method !== 'object') continue
+
       if (method.type === 'bank_account') {
         const bankMethod: BankAccountDonationMethod = {
           type: 'bank_account',
-          bank: method.bank ?? null,
-          holder: method.holder ?? null,
-          number: method.number ?? null,
-          description: method.description ?? null
+          bank: toOptionalString(method.bank) ?? null,
+          holder: toOptionalString(method.holder) ?? null,
+          number: toOptionalString(method.number) ?? null,
+          description: toOptionalString(method.description) ?? null
         }
         if (hasContent(bankMethod)) normalized.push(bankMethod)
-      } else if (method.type === 'link' && method.url) {
-        normalized.push({
-          type: 'link',
-          url: method.url,
-          label: method.label ?? null
-        })
-      } else if (method.type === 'custom' && method.value) {
-        normalized.push({
-          type: 'custom',
-          value: method.value,
-          label: method.label ?? null
-        })
+      } else if (method.type === 'link') {
+        const url = toOptionalString(method.url)
+        if (url) {
+          const label = toOptionalString(method.label)
+          normalized.push(
+            label
+              ? { type: 'link', url, label }
+              : { type: 'link', url }
+          )
+        }
+      } else if (method.type === 'custom') {
+        const value = toOptionalString(method.value)
+        if (value) {
+          const label = toOptionalString(method.label)
+          normalized.push(
+            label
+              ? { type: 'custom', value, label }
+              : { type: 'custom', value }
+          )
+        }
       }
     }
   }
 
-  if (donation.account) {
-    normalized.push({
-      type: 'bank_account',
-      number: donation.account
-    })
-  }
+  const accountNumber =
+    toOptionalString(donationObject.account) ??
+    toOptionalString(donationObject.account_number) ??
+    toOptionalString(donationObject.accountNumber)
 
-  if (donation.page_url) {
-    const alreadyHasLink = normalized.some(
-      (method) => method.type === 'link' && method.url === donation.page_url
+  const bankName = toOptionalString(donationObject.bank)
+  const holderName = toOptionalString(donationObject.holder)
+  const accountDescription =
+    toOptionalString(donationObject.description) ??
+    toOptionalString(donationObject.account_description)
+
+  if (accountNumber) {
+    const existingAccount = normalized.find(
+      (method) => isBankAccountMethod(method) && method.number === accountNumber
     )
 
-    if (!alreadyHasLink) {
+    if (existingAccount && isBankAccountMethod(existingAccount)) {
+      if (!existingAccount.bank && bankName) existingAccount.bank = bankName
+      if (!existingAccount.holder && holderName) existingAccount.holder = holderName
+      if (!existingAccount.description && accountDescription) {
+        existingAccount.description = accountDescription
+      }
+    } else {
       normalized.push({
-        type: 'link',
-        url: donation.page_url,
-        label: donation.note ? undefined : '후원 페이지'
+        type: 'bank_account',
+        number: accountNumber,
+        bank: bankName ?? null,
+        holder: holderName ?? null,
+        description: accountDescription ?? null
       })
+    }
+  }
+
+  const customLinkLabel =
+    toOptionalString(donationObject.link_label) ??
+    toOptionalString(donationObject.linkLabel)
+
+  const pageUrl =
+    toOptionalString(donationObject.page_url) ??
+    toOptionalString(donationObject.pageUrl) ??
+    toOptionalString(donationObject.url)
+
+  if (pageUrl) {
+    const existingLink = normalized.find(
+      (method) => isLinkMethod(method) && method.url === pageUrl
+    )
+
+    if (existingLink && isLinkMethod(existingLink)) {
+      if (!existingLink.label && customLinkLabel) {
+        existingLink.label = customLinkLabel
+      }
+    } else {
+      const label = customLinkLabel ?? (note ? undefined : '후원 페이지')
+      normalized.push(
+        label
+          ? { type: 'link', url: pageUrl, label }
+          : { type: 'link', url: pageUrl }
+      )
     }
   }
 


### PR DESCRIPTION
## Summary
- make donation normalization resilient to JSON strings and extra fields used in Supabase rows
- extract helpers to trim string values and enrich bank account data with bank/holder info when available
- ensure `page_url` and related aliases always yield a link method so the contribute page lists institutions with donation pages

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d4d13cbb7c832aadd7f5bd7705c996